### PR TITLE
Support compilation on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,7 +277,7 @@ target_include_directories (tm PRIVATE src)
 target_link_libraries (tm PUBLIC libopenmpt tm_external ${SDL2_LIBRARIES})
 if (WIN32)
     target_link_libraries (tm PUBLIC opengl32)
-else ()
+elseif (NOT APPLE)
     target_link_libraries (tm PUBLIC m dl GL)
 endif ()
 

--- a/src/main_sdl2.cpp
+++ b/src/main_sdl2.cpp
@@ -244,7 +244,10 @@ int main(int argc, char* argv[]) {
                     break;
                 case SDL_WINDOWEVENT:
                     if (ev.window.event == SDL_WINDOWEVENT_RESIZED) {
-                        app.handleResize(ev.window.data1, ev.window.data2);
+                        int rw = 0, rh = 0;
+                        // get actual drawable size of the window in pixels to account for high-DPI on macOS
+                        SDL_GL_GetDrawableSize(priv.win, &rw, &rh);
+                        app.handleResize(rw, rh);
                     }
                     break;
                 case SDL_QUIT:


### PR DESCRIPTION
Please note that this doesn't address the whole rigamarole around creating a releasable binary for macOS suitable for public consumption with code signing and such, this was just me scratching my own itch. 😄

When using SDL on macOS, there's no need to link against OpenGL because SDL as installed by Homebrew already brings in the OpenGL framework, and -lGL does not work on that platform anyway.

Also on macOS, the SDL window resize event returns the window size in points which on high-DPI screens is 2x the number of pixels. Using SDL_GL_GetDrawableSize returns the actual pixel size of the window.

